### PR TITLE
Save report_df as pickle for Streamlit integration

### DIFF
--- a/regression/report_generator.py
+++ b/regression/report_generator.py
@@ -1,24 +1,35 @@
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
+import joblib
+import os
 
 # Explanation: Summarize metrics for all models using provided R2 values.
 # Generate a report table and plot for comparison.
+# Save report_df for use in Streamlit.
 
 # Define model metrics (using provided values)
-models = ['Linear Regression', 'Decision Tree', 'Random Forest', 'Gradient Boosting', 'XGBoost', 'Stacking', 'Bagging', 'AdaBoost']
-r2_scores = [0.30, 0.37, 0.49, 0.48, 0.49, None, None, None]  # Placeholder for Stacking, Bagging, AdaBoost
+models = ['Linear Regression', 'Decision Tree', 'Random Forest',
+          'Gradient Boosting', 'XGBoost', 'Stacking', 'Bagging', 'AdaBoost']
+# Placeholder for Stacking, Bagging, AdaBoost
+r2_scores = [0.30, 0.37, 0.49, 0.48, 0.49, None, None, None]
 
-# Update R2 scores for ensemble models after running them
-# Placeholder values will be replaced with actuals once computed
+# Create report DataFrame
 report_df = pd.DataFrame({'Model': models, 'R2': r2_scores})
+
+# Save report_df
+os.makedirs('data/processed', exist_ok=True)
+joblib.dump(report_df, 'data/processed/report_df.pkl')
+print("Saved report_df to data/processed/report_df.pkl")
+
+# Print report
 print("Model Performance Report:\n", report_df)
 
 # Insights based on provided metrics
 print("\nInsights:")
 print("- Best model: Random Forest and XGBoost (R2=0.49), followed by Gradient Boosting (R2=0.48).")
 print("- Linear Regression (R2=0.30) and Decision Tree (R2=0.37) underperformed, likely due to non-linear patterns.")
-print("- Key features: Likely neighbourhood_encoded, days_since_last_review, has_luxury (based on RF importance).")
+print("- Key features: Likely neighbourhood_encoded, days_since_last_review, availability_365 (based on RF importance).")
 print("- Log transform improved normality, but R2 <0.5 suggests missing features (e.g., amenities, seasonality).")
 print("- Ensemble models (Stacking, Bagging, AdaBoost) may improve R2 to ~0.55–0.60.")
 


### PR DESCRIPTION
Added code to save the model performance report DataFrame (report_df) as a pickle file in data/processed/report_df.pkl using joblib. This enables reuse in Streamlit apps. Also updated feature insights and ensured the output directory exists.